### PR TITLE
Feature: Show StopWatch on the Lock-Screen

### DIFF
--- a/src/com/kodarkooperativet/notificationstopwatch/TimeService.java
+++ b/src/com/kodarkooperativet/notificationstopwatch/TimeService.java
@@ -104,6 +104,7 @@ public class TimeService extends Service implements PropertyChangeListener {
 	public void onCreate() {
     	mBuilder = new Notification.Builder(this)
     	        .setSmallIcon(R.drawable.ic_launcher)
+                .setVisibility(VISIBILITY_PUBLIC)
     	        .setOnlyAlertOnce(true);
 		super.onCreate();
 	}

--- a/src/com/kodarkooperativet/notificationstopwatch/TimeService.java
+++ b/src/com/kodarkooperativet/notificationstopwatch/TimeService.java
@@ -104,7 +104,7 @@ public class TimeService extends Service implements PropertyChangeListener {
 	public void onCreate() {
     	mBuilder = new Notification.Builder(this)
     	        .setSmallIcon(R.drawable.ic_launcher)
-                .setVisibility(VISIBILITY_PUBLIC)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
     	        .setOnlyAlertOnce(true);
 		super.onCreate();
 	}


### PR DESCRIPTION
Sets the Visibility of the Notification to VISIBILITY_PUBLIC instead of
using the default VISIBILITY_PRIVATE.

My main interest in this app is to be able to stop a stopwatch time
easily w/o having to unlock my phone. I don't know of a use case in
which this change would be a privacy issue.